### PR TITLE
Update button text to account for slow website latency

### DIFF
--- a/frontend/checkout.phtml
+++ b/frontend/checkout.phtml
@@ -97,6 +97,7 @@ jQuery(document).ready(function($){
             $('.modal-container').hide();
         }, 300)
         document.getElementById("btn-razorpay").disabled = false;
+        document.getElementById("btn-razorpay").innerHTML = "Pay with Razorpay";
     }
 
     $('.close').click(hideModal);
@@ -132,6 +133,7 @@ jQuery(document).ready(function($){
                 order.modal = {
                     ondismiss: function(){
                         document.getElementById("btn-razorpay").disabled = false;
+                        document.getElementById("btn-razorpay").innerHTML = "Pay with Razorpay";
                     }
                 };
 
@@ -149,6 +151,7 @@ jQuery(document).ready(function($){
 
     function disableRzpButton(){
         document.getElementById("btn-razorpay").disabled = true;
+        document.getElementById("btn-razorpay").innerHTML = "Processing...";
     }
 
 


### PR DESCRIPTION
In cases where a website loads very slowly, the GET + POST takes too
much time during which the payment button is non-responsive and
there's nothing else to indicate that something has actually happened.
Update the button text to 'Processing...' to indicate that the
button click actually did something.