### PR TITLE
Harden page_id handling in order creation endpoint

### DIFF
--- a/razorpay-quick-payments.php
+++ b/razorpay-quick-payments.php
@@ -137,12 +137,19 @@ function wordpressRazorpayInit()
         {
             if (empty($_GET['page_id']) === false)
             {
+                $pageID = absint(wp_unslash($_GET['page_id']));
+
+                if ($pageID <= 0)
+                {
+                    header('Content-Type: application/json');
+                    echo wp_json_encode(array('error' => 'Invalid page ID'));
+                    return;
+                }
+
                 // Random order ID
                 $orderID = (string)mt_rand(0, mt_getrandmax());
 
                 // Create a custom field and call it 'amount', and assign the value in paise
-                $pageID = $_GET['page_id'];
-
                 $metadata = get_post_meta($pageID);
 
                 if (empty($metadata) === true)


### PR DESCRIPTION
TLDR:
- Sanitizes incoming page_id via `absint` and `wp_unslash`.
- Adds early JSON error for invalid IDs.
- Keeps existing flow unchanged for valid IDs.
---
This pull request adds validation for the `page_id` parameter in the `razorpayOrderCreationResponse()` function to improve error handling and prevent invalid input.

**Input validation and error handling:**

* Added a check to ensure the `page_id` is a positive integer, returning a JSON error response and stopping execution if it is invalid.
* Sanitized and type-cast the `page_id` parameter using `wp_unslash()` and `absint()` before using it.